### PR TITLE
デフォルトmigrationファイルの修正

### DIFF
--- a/database/migrations/2021_03_21_035148_create_user_tables.php
+++ b/database/migrations/2021_03_21_035148_create_user_tables.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateUsersTable extends Migration
+class CreateUserTables extends Migration
 {
     /**
      * Run the migrations.
@@ -13,7 +13,7 @@ class CreateUsersTable extends Migration
      */
     public function up()
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('user_tables', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
             $table->string('email')->unique();
@@ -21,7 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
-        });
+      });
     }
 
     /**
@@ -31,6 +31,6 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('users');
+        Schema::dropIfExists('user_tables');
     }
 }


### PR DESCRIPTION
デフォルトmigrationファイルだと以下エラーでテーブルが作成できないため修正

```
kor@kor-MacBook-Pro laravel-game-strategy % php artisan migrate

   Symfony\Component\Debug\Exception\FatalThrowableError  : Class 'CreateUserTable' not found

  at /Users/kor/Desktop/git_game/laravel-game-strategy/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:453
    449|     public function resolve($file)
    450|     {
    451|         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
    452| 
  > 453|         return new $class;
    454|     }
    455| 
    456|     /**
    457|      * Get all of the migration files in a given path.

  Exception trace:

  1   Illuminate\Database\Migrations\Migrator::resolve("2014_10_12_000000_create_user_table")
      /Users/kor/Desktop/git_game/laravel-game-strategy/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:189

  2   Illuminate\Database\Migrations\Migrator::runUp("/Users/kor/Desktop/git_game/laravel-game-strategy/database/migrations/2014_10_12_000000_create_user_table.php")
      /Users/kor/Desktop/git_game/laravel-game-strategy/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:165

  Please use the argument -v to see more details.
```